### PR TITLE
removes hardcoded output

### DIFF
--- a/src/tspegjs.js
+++ b/src/tspegjs.js
@@ -3,7 +3,6 @@ exports.use = function (config, options) {
     require("./passes/generate-bytecode-ts"),
     require("./passes/generate-ts")
   ];
-  options.output = "source";
   if (!options.tspegjs) {
     options.tspegjs = {};
   }


### PR DESCRIPTION
Removes the hardcoded `output` option. Now by default, "parser" is used, like with normal PEG.js, and the option passed in parameters will be used.