### PR TITLE
fix(generator): export type Expectation

### DIFF
--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -806,7 +806,7 @@ function generateTS(ast, options) {
       "  description: string;",
       "}",
       "",
-      "type Expectation = ILiteralExpectation | IClassExpectation | IAnyExpectation | IEndExpectation | IOtherExpectation;",
+      "export type Expectation = ILiteralExpectation | IClassExpectation | IAnyExpectation | IEndExpectation | IOtherExpectation;",
       "",
       "export class SyntaxError extends Error {",
       "  public static buildMessage(expected: Expectation[], found: string | null) {",


### PR DESCRIPTION
our automated mocha tests are failing as the typescript compiler fails with the message
Parameter 'expected' of public static method from exported class has or is using private name 'Expectation'

Since this type is consumed by external clients, with one of the latest TypeScript versions we do get this issue