### PR TITLE
feat(customHeader): Moved to be first item

### DIFF
--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -767,9 +767,6 @@ function generateTS(ast, ...args) {
   function generateToplevel() {
     let parts = [];
 
-    if (options.tspegjs.customHeader) {
-      parts.push(options.tspegjs.customHeader);
-    }
     parts.push([
       "export interface IFilePosition {",
       "  offset: number;",
@@ -1283,6 +1280,9 @@ function generateTS(ast, ...args) {
   function generateWrapper(toplevelCode) {
     function generateGeneratedByComment() {
       let res = [];
+      if (options.tspegjs.customHeader) {
+        res.push(options.tspegjs.customHeader);
+      }
       if (!options.tspegjs.noTslint) {
         if (options.tspegjs.tslintIgnores) {
           // apply user custom exclusions


### PR DESCRIPTION
Fixed #47

A tslint has been deprecated and eslint is now used, and with the custom header you could now add a /* es-lint- disable */ at the top of the file or custom eslint rules