### PR TITLE
Force TypeScript to not infer types when matching empty string rules

### DIFF
--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -620,15 +620,15 @@ function generateTS(ast, ...args) {
             break;
 
           case op.IF_ERROR: // IF_ERROR t, f
-            compileCondition(stack.top() + " === peg$FAILED", 0);
+            compileCondition(stack.top() + " as any === peg$FAILED", 0);
             break;
 
           case op.IF_NOT_ERROR: // IF_NOT_ERROR t, f
-            compileCondition(stack.top() + " !== peg$FAILED", 0);
+            compileCondition(stack.top() + " as any !== peg$FAILED", 0);
             break;
 
           case op.WHILE_NOT_ERROR: // WHILE_NOT_ERROR b
-            compileLoop(stack.top() + " !== peg$FAILED", 0);
+            compileLoop(stack.top() + " as any !== peg$FAILED", 0);
             break;
 
           case op.MATCH_ANY: // MATCH_ANY a, f, ...


### PR DESCRIPTION
Force TypeScript to not infer types when matching empty string rules.  For example this rule:
```
Empty
  = "" {
    return "";
  }
```
Generates this code:
```
  function peg$parseEmpty(): any {
    let s0, s1;

    s0 = peg$currPos;
    s1 = peg$c30;
    if (s1 !== peg$FAILED) {
      peg$savedPos = s0;
      s1 = peg$c31();
    }
    s0 = s1;

    return s0;
  }
```
The TypeScript compiler will infer that `s1` is a string and can never equal `peg$FAILED` because the types overlap.  This change forces `s1` to be treated as `any` and avoids the compiler error.