### PR TITLE
Fix peggy dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "lint": "eslint src/"
     },
     "peerDependencies": {
-        "peggy": "1.1.0"
+        "peggy": "^1.1.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.25.0",
@@ -75,6 +75,6 @@
         "typescript": "^4.2.4"
     },
     "dependencies": {
-        "peggy": "1.1.0"
+        "peggy": "^1.1.0"
     }
 }


### PR DESCRIPTION
The version of peggy is fixed by `peerDependencies` and `dependencies`.

### What was a problem

Currently, when I try to use the latest version of peggy@1.2.0, the following worning is displayed.

```
warning "> ts-pegjs@1.0.0" has incorrect peer dependency "peggy@1.1.0".
```

### How this PR fixes the problem

Fixed peggy's `1.1.0 <=, <2.0.0` range to be supported using`^`.

### Additional Comments

I had an idea to set `peerDependencies` to` ^1.0.0` and `dependencies` to`^1.2.0`, but I left the version specification as it is.
