### PR TITLE
Support top level initializer block

### DIFF
--- a/examples/javascript.pegjs
+++ b/examples/javascript.pegjs
@@ -30,21 +30,27 @@
 // [3] http://inimino.org/~inimino/blog/
 // [4] http://boshi.inimino.org/3box/asof/1270029991384/PEG/ECMAScript_unified.peg
 
+{{
+const TYPES_TO_PROPERTY_NAMES = {
+  CallExpression:   "callee",
+  MemberExpression: "object",
+};
+
+function filledArray(count, value) {
+  return Array.apply(null, new Array(count))
+    .map(function() { return value; });
+}
+
+function extractOptional(optional, index) {
+  return optional ? optional[index] : null;
+}
+
+function optionalList(value) {
+  return value !== null ? value : [];
+}
+}}
+
 {
-  const TYPES_TO_PROPERTY_NAMES = {
-    CallExpression:   "callee",
-    MemberExpression: "object",
-  };
-
-  function filledArray(count, value) {
-    return Array.apply(null, new Array(count))
-      .map(function() { return value; });
-  }
-
-  function extractOptional(optional, index) {
-    return optional ? optional[index] : null;
-  }
-
   function extractList(list, index) {
     return list.map(function(element) { return element[index]; });
   }
@@ -73,10 +79,6 @@
         right: element[3]
       };
     }, head);
-  }
-
-  function optionalList(value) {
-    return value !== null ? value : [];
   }
 }
 

--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -1006,6 +1006,11 @@ function generateTS(ast, ...args) {
       ].join("\n"));
     }
 
+    if (ast.topLevelInitializer) {
+      parts.push(ast.topLevelInitializer.code);
+      parts.push("");
+    }
+
     parts.push([
       "function peg$parse(input: string, options?: IParseOptions) {",
       "  options = options !== undefined ? options : {};",

--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -767,6 +767,11 @@ function generateTS(ast, ...args) {
   function generateToplevel() {
     let parts = [];
 
+    if (ast.topLevelInitializer) {
+      parts.push(ast.topLevelInitializer.code);
+      parts.push("");
+    }
+
     parts.push([
       "export interface IFilePosition {",
       "  offset: number;",
@@ -1004,11 +1009,6 @@ function generateTS(ast, ...args) {
         "}",
         "",
       ].join("\n"));
-    }
-
-    if (ast.topLevelInitializer) {
-      parts.push(ast.topLevelInitializer.code);
-      parts.push("");
     }
 
     parts.push([


### PR DESCRIPTION
In peggy@1.1.0, the function of `top level initializer block` is added, and constants and functions can be defined in the module.

Utilizing this feature in `ts-pegjs` solves the problem of type definition that was previously imported from the outside with `customHeader`, such as defining interface and type.

see https://github.com/peggyjs/peggy/pull/73

### Additional commemt

I was wondering where to insert the `top level initializer block`, but now I insert it at the top as peggy does.
