### PR TITLE
Add missing file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "src/tspegjs.js",
         "src/passes/generate-bytecode-ts.js",
         "src/passes/generate-ts.js",
+        "src/passes/js.js",
         "output/.eslintrc",
         "test/README",
         "test/test.js"


### PR DESCRIPTION
Hi @pjmolina ,
First, thank you for the release!

When running with version 1.1.0, an error occurred.

```
Cannot find module './js'
```

The `js.js` added earlier did not exist in the library under node_module.

I added `src/passes/js.js` to files in package.json.