### PR TITLE
Support multiline customHeader

### DIFF
--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -1332,7 +1332,11 @@ function generateTS(ast, ...args) {
     function generateGeneratedByComment() {
       let res = [];
       if (options.tspegjs.customHeader) {
-        res.push(options.tspegjs.customHeader);
+        if (Array.isArray(options.tspegjs.customHeader)) {
+          res.concat(options.tspegjs.customHeader);
+        } else {
+          res.push(options.tspegjs.customHeader);
+        }
       }
       res = res.concat([
         "",


### PR DESCRIPTION
Support for passing array of strings as `customHeader` parameter. May be very useful when customHeader is used to define multiple `type`s, which are later used as return types in `returnTypes`. It it possible to use define types in a single line, dividing them with `\n`, but the new approach is way more readable, i.e.:
```
{
  "tspegjs": {
    "customHeader": [
      "type VehicleType = {type: string, model: string, registration: string}",
      "type UfoType = {type: string, diameter: number}"
    ]
  },
  "returnTypes": {
    "CAR": "VehicleType",
    "MOTORCYCLE": "VehicleType",
    "UFO": "UfoType"
  }
}
```