### PR TITLE
Use `import = require()` for commonjs

### DIFF
--- a/src/passes/generate-ts.js
+++ b/src/passes/generate-ts.js
@@ -1449,7 +1449,7 @@ function generateTS(ast, options, session) {
 
         if (dependencyVars.length > 0) {
           dependencyVars.forEach(variable => {
-            parts.push("let " + variable +
+            parts.push("import " + variable +
               " = require(\"" +
               js.stringEscape(options.dependencies[variable]) +
               "\");"


### PR DESCRIPTION
Closes #90.
Replaces `let` with `import` for type & bundler support.
https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require