### PR TITLE
rename grammarSource->source 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,7 +35,7 @@
 
 ## Version 2.2.1
 
-- Fix [#84](https://github.com/metadevpro/ts-pegjs/issues/84) Same convetion as peggy. Make `grammarSource` optional.
+- Fix [#84](https://github.com/metadevpro/ts-pegjs/issues/84) Same convention as peggy. Make `grammarSource` optional.
 
 ## Version 2.2.0
 

--- a/src/passes/constants.ts
+++ b/src/passes/constants.ts
@@ -53,7 +53,7 @@ declare class _PeggySyntaxError extends Error {
   public name: string;
   constructor(message: string, expected: Expectation[], found: string | null, location: FileRange);
   format(sources: {
-    grammarSource?: string;
+    source?: any;
     text: string;
   }[]): string;
 }

--- a/test/arithmetics.test.ts
+++ b/test/arithmetics.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import * as fs from 'node:fs/promises';
+import { exec as execNode } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { exec as execNode } from 'node:child_process';
 import peggy from 'peggy';
+import { describe, expect, it } from 'vitest';
 
 // Local imports
 import tspegjs from '../src/tspegjs';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
 
 /**
  * The main configuration for Vite. This config includes
@@ -14,5 +14,5 @@ export default defineConfig({
     lib: { entry: ['./src/cli.ts', './src/tspegjs.ts'], formats: ['es', 'cjs'] },
     rollupOptions: { external: [/^node:/, 'peggy', 'ts-morph', /^prettier/] }
   },
-  test: { globals: true, testTimeout: 20000 }
+  test: { globals: true, testTimeout: 25000 }
 });


### PR DESCRIPTION
Rename `grammarSource`-> `source` to be compliant with peggy. 
fix #101