### PR TITLE
fix: export config and options

### DIFF
--- a/src/tspegjs.ts
+++ b/src/tspegjs.ts
@@ -2,6 +2,8 @@ import type { Config } from 'peggy';
 import { generateParser } from './passes/generate-ts';
 import { TsPegjsParserBuildOptions } from './types';
 
+export * from "./types";
+
 export default {
   use(config: Config, options: TsPegjsParserBuildOptions) {
     // We depend on the code generated being an IIF


### PR DESCRIPTION
`TsPegjsParserBuildOptions` and `TsPegjsOptions` are not exported. This PR fixes this.