### PR TITLE
fix: import of Prettier TypeScript plugin

### DIFF
--- a/src/libs/type-extractor.ts
+++ b/src/libs/type-extractor.ts
@@ -1,6 +1,6 @@
 import type { ast } from 'peggy';
 import * as peggy from 'peggy';
-import * as prettierPluginTypescript from 'prettier/parser-typescript';
+import prettierPluginTypescript from 'prettier/parser-typescript';
 import prettier from 'prettier/standalone';
 import { Project, ScriptTarget, ts } from 'ts-morph';
 import { getUniqueName, isKeyword } from './get-unique-name';


### PR DESCRIPTION
While migrating a project that depends on ts-pegjs to ESM, I ran into a runtime error related to the Prettier TS plugin.

In
https://github.com/prettier/prettier/blob/6b582a061992ee614631b0ff196d92faad86c6c3/src/plugins/typescript.js#L1
the plugin is exported as a named export `parsers`.

This is accessed later in
https://github.com/prettier/prettier/blob/6b582a061992ee614631b0ff196d92faad86c6c3/src/plugins/builtin-plugins-proxy.js#L34
which expects to be able to access the `parsers` property of the plugin

By importing the plugin with `* as ...`, an additional wrapper object is added, resulting in `prettierPluginTypescript` to have the shape
```
{ default: { parsers: { typescript: [Object] } } }
```

instead of the expected
```
{ parsers: { typescript: [Object] } }
```